### PR TITLE
Add XS0B-MR smoke detector support

### DIFF
--- a/xsense/entity_map.py
+++ b/xsense/entity_map.py
@@ -178,6 +178,14 @@ entities = {
             TestAction(),
         ],
     },
+    'XS0B-MR': {
+        'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+            MuteAction(),
+            FireDrillAction(),
+        ],
+    },
     'XS03-iWX': {
         # Smoke RF
         'type': EntityType.SMOKE,


### PR DESCRIPTION
Add entity mapping for the XS0B-MR smoke detector with support for:
- TestAction: device self-test
- MuteAction: mute active alarm
- FireDrillAction: trigger fire drill

This enables Home Assistant integrations to expose test, mute, and fire drill buttons for XS0B-MR devices.