### PR TITLE
Add XS0B-MR smoke detector support

### DIFF
--- a/xsense/entity_map.py
+++ b/xsense/entity_map.py
@@ -149,6 +149,7 @@ entities = {
     'XH02-M': {
         'type': EntityType.HEAT,
         'actions': [
+            TestAction(shadow='appXh02mSelfTest'),
         ]
     },
     'XP0A-MR': {

--- a/xsense/entity_map.py
+++ b/xsense/entity_map.py
@@ -165,6 +165,13 @@ entities = {
             TestAction(shadow='app2ndSelfTest'),
         ]
     },
+    'XS0B-MR': {
+        'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(shadow='app2ndSelfTest'),
+            MuteAction(),
+        ],
+    },
     'XS01-M': {
         'type': EntityType.SMOKE,
         'actions': [


### PR DESCRIPTION
## Summary
- Adds entity mapping for X-Sense XS0B-MR smart smoke detector
- Includes test action (`app2ndSelfTest` shadow) and mute action
- MQTT topic/payload confirmed working by user in Jarnsen/ha-xsense-component_test#88

## Context
The XS0B-MR is a smoke detector that works with the SBS50 base station. It supports both test and mute via the X-Sense app, but was missing from the entity map. Several users have reported this in Jarnsen/ha-xsense-component_test#88.