### PR TITLE
Add APK-backed control commands

### DIFF
--- a/xsense/async_xsense.py
+++ b/xsense/async_xsense.py
@@ -246,22 +246,9 @@ class AsyncXSense(XSenseBase):
             raise APIFailure(f'Unable to retrieve station data: {self._lastres.status}/{text}')
 
     async def set_state(self, entity: Entity, shadow: str, topic: str, definition: Dict):
-        station = entity.station
-        t = datetime.now()
-        timestamp = t.strftime('%Y%m%d%H%M%S')
+        station, data = self.build_desired_state(entity, shadow, definition)
 
-        desired = {
-            "deviceSN": entity.sn,
-            "shadow": shadow,
-            "stationSN": station.sn,
-            "time": timestamp,
-            "userId": self.userid
-        }
-        desired.update(definition.get('extra', {}))
-
-        data = {"state": {"desired": desired}}
-
-        res = await self.do_thing(station, topic, data)
+        return await self.do_thing(station, topic, data)
 
     async def action(self, entity: Entity, action: str):
         entity_def = entities.get(entity.type)
@@ -275,4 +262,4 @@ class AsyncXSense(XSenseBase):
         topic = action_def.get('topic')
         if callable(topic):
             topic = topic(entity)
-        await self.set_state(entity, action_def['shadow'], topic, action_def)
+        return await self.set_state(entity, action_def['shadow'], topic, action_def)

--- a/xsense/async_xsense.py
+++ b/xsense/async_xsense.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime
 import json
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 import aiohttp
 
@@ -250,6 +250,11 @@ class AsyncXSense(XSenseBase):
 
         return await self.do_thing(station, topic, data)
 
+    async def set_device_config(self, entity: Entity, **values):
+        shadow = "infoBase" if isinstance(entity, Station) else "infoDev"
+        station, data = self.build_config_state(entity, shadow, values)
+        return await self.do_thing(station, f'2nd_cfg_{entity.sn}', data)
+
     async def set_alarm_volume(self, entity: Entity, volume: int, alarm_tone: Optional[str]=None, mute: Optional[str]=None):
         self._validate_volume(volume)
         values = {
@@ -268,6 +273,238 @@ class AsyncXSense(XSenseBase):
         self._validate_volume(volume)
         station, data = self.build_config_state(station, "infoBase", {"voiceVol": str(volume)})
         return await self.do_thing(station, f'2nd_cfg_{station.sn}', data)
+
+    async def set_station_mode(self, station: Station, safe_mode: str, force_arm: Optional[str]=None):
+        values = {
+            "userParam": "source=1",
+            "source": "1",
+            "safeMode": safe_mode,
+        }
+        if force_arm is not None:
+            values["forceArm"] = force_arm
+
+        station, data = self.build_command_state(
+            station,
+            "appMode",
+            values,
+            include_device=False,
+            include_time=False
+        )
+        return await self.do_thing(station, "2nd_appmode", data)
+
+    async def trigger_sos(self, station: Station, sos_type: str='1'):
+        station, data = self.build_command_state(
+            station,
+            "sosDown",
+            {
+                "userParam": "source=1",
+                "sosType": sos_type,
+            },
+            include_device=False
+        )
+        return await self.do_thing(station, "2nd_sosdown", data)
+
+    async def cancel_sos(self, station: Station):
+        station, data = self.build_command_state(
+            station,
+            "sosDown",
+            {"sosStatus": "0"},
+            include_device=False
+        )
+        return await self.do_thing(station, "sosdown", data)
+
+    async def cancel_alarm(self, station: Station):
+        station, data = self.build_command_state(
+            station,
+            "alarmCancel",
+            {"cancelTime": self._utc_timestamp()},
+            include_device=False,
+            include_time=False
+        )
+        return await self.do_thing(station, "alarmcancel", data)
+
+    async def set_fire_drill(
+            self,
+            entity: Entity,
+            drill: Union[bool, str]=True,
+            drill_time: Optional[str]=None,
+            alarm_type: Optional[str]=None,
+            alarm_vol: Optional[str]=None,
+            alarm_tone: Optional[str]=None,
+            location: Optional[str]=None,
+            stop_reason: Optional[str]=None
+    ):
+        values = {"drill": self._bool_value(drill)}
+        optional = {
+            "drillTime": drill_time,
+            "alarmType": alarm_type,
+            "alarmVol": alarm_vol,
+            "alarmTone": alarm_tone,
+            "location": location,
+            "stopReason": stop_reason,
+        }
+        values.update({k: v for k, v in optional.items() if v is not None})
+        if not isinstance(entity, Station):
+            values["deviceType"] = entity.type
+
+        station, data = self.build_command_state(
+            entity,
+            "appFireDrill",
+            values,
+            include_device=not isinstance(entity, Station)
+        )
+        return await self.do_thing(station, "2nd_firedrill", data)
+
+    async def set_sos_sound(self, station: Station, sos_sound: str):
+        station, data = self.build_command_state(
+            station,
+            "sosParam",
+            {
+                "userParam": "source=1",
+                "sosSound": sos_sound,
+            },
+            include_device=False
+        )
+        return await self.do_thing(station, "2nd_sosparam", data)
+
+    async def activate_device(self, entity: Entity):
+        station, data = self.build_command_state(
+            entity,
+            "app2ndActivate",
+            {"activate": "1"},
+            include_device=True
+        )
+        return await self.do_thing(station, "2nd_appactivate", data)
+
+    async def set_install_guide_test(
+            self,
+            entity: Entity,
+            active: Union[bool, str]=True,
+            dev_type: Optional[str]=None,
+            test_time: str='180',
+            detc_sens: Optional[str]=None
+    ):
+        values = {
+            "devType": dev_type or entity.type,
+            "test": self._bool_value(active),
+            "testTime": test_time,
+        }
+        if detc_sens is not None:
+            values["detcSens"] = detc_sens
+
+        station, data = self.build_command_state(entity, "appInstallGuide", values, include_device=True)
+        return await self.do_thing(station, "2nd_appinstallguide", data)
+
+    async def signal_test(
+            self,
+            entity: Entity,
+            dev_type: Optional[str]=None,
+            test: Union[bool, str]=True,
+            test_time: str='5'
+    ):
+        station, data = self.build_command_state(
+            entity,
+            "signalTest",
+            {
+                "devType": dev_type or entity.type,
+                "test": self._bool_value(test),
+                "testTime": test_time,
+            },
+            include_device=True
+        )
+        return await self.do_thing(station, f'2nd_signaltest_{entity.sn}', data)
+
+    async def set_motion_test(self, entity: Entity, active: Union[bool, str]=True, dev_type: str='SMS01'):
+        station, data = self.build_command_state(
+            entity,
+            "testIR",
+            {
+                "devType": dev_type,
+                "testIR": self._bool_value(active),
+            },
+            include_device=True,
+            include_time=False,
+            include_user=False
+        )
+        return await self.do_thing(station, "testir", data)
+
+    async def set_light_power(self, entity: Entity, on: Union[bool, str]):
+        station, data = self.build_command_state(
+            entity,
+            "lampPower",
+            {
+                "userParam": "source=1",
+                "isOn": self._bool_value(on),
+                "dev": entity.sn,
+            },
+            include_device=False
+        )
+        return await self.do_thing(station, "2nd_lamppower", data)
+
+    async def set_light_group_power(
+            self,
+            station: Station,
+            group_id: str,
+            device_sns: List[str],
+            on: Union[bool, str],
+            timeout: str='180'
+    ):
+        station, data = self.build_command_state(
+            station,
+            "groupLampPower",
+            {
+                "userParam": "source=1",
+                "timeOut": timeout,
+                "groupId": group_id,
+                "devs": device_sns,
+                "isOn": self._bool_value(on),
+            },
+            include_device=False
+        )
+        return await self.do_thing(station, "2nd_grouppower", data)
+
+    async def mute_water(
+            self,
+            entity: Entity,
+            set_type: str='0',
+            silence_time: str='',
+            trigger_source: Optional[str]=None
+    ):
+        values = {
+            "setType": set_type,
+            "silenceTime": silence_time,
+        }
+        if trigger_source is not None:
+            values["triggerSource"] = trigger_source
+
+        station, data = self.build_command_state(
+            entity,
+            "appWater",
+            values,
+            include_device=True
+        )
+        return await self.do_thing(station, "2nd_appwater", data)
+
+    async def mute_temperature_humidity(self, entity: Entity, mute_type: str='1', sensor_type: Optional[str]=None):
+        station, data = self.build_command_state(
+            entity,
+            "extendMute",
+            {
+                "muteType": mute_type,
+                "type": sensor_type or entity.type,
+            },
+            include_device=True
+        )
+        return await self.do_thing(station, "2nd_appmute", data)
+
+    async def mute_driveway(self, entity: Entity, mute: Union[bool, str]=True, topic: str='2nd_driveway'):
+        station, data = self.build_command_state(
+            entity,
+            "appDriveway",
+            {"mute": self._bool_value(mute)},
+            include_device=True
+        )
+        return await self.do_thing(station, topic, data)
 
     async def action(self, entity: Entity, action: str):
         entity_def = entities.get(entity.type)

--- a/xsense/async_xsense.py
+++ b/xsense/async_xsense.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime
 import json
-from typing import Dict
+from typing import Dict, Optional
 
 import aiohttp
 
@@ -249,6 +249,25 @@ class AsyncXSense(XSenseBase):
         station, data = self.build_desired_state(entity, shadow, definition)
 
         return await self.do_thing(station, topic, data)
+
+    async def set_alarm_volume(self, entity: Entity, volume: int, alarm_tone: Optional[str]=None, mute: Optional[str]=None):
+        self._validate_volume(volume)
+        values = {
+            "alarmVol": str(volume),
+        }
+        if alarm_tone is not None:
+            values["alarmTone"] = alarm_tone
+        if mute is not None:
+            values["mute"] = mute
+
+        shadow = "infoBase" if isinstance(entity, Station) else "infoDev"
+        station, data = self.build_config_state(entity, shadow, values)
+        return await self.do_thing(station, f'2nd_cfg_{entity.sn}', data)
+
+    async def set_voice_volume(self, station: Station, volume: int):
+        self._validate_volume(volume)
+        station, data = self.build_config_state(station, "infoBase", {"voiceVol": str(volume)})
+        return await self.do_thing(station, f'2nd_cfg_{station.sn}', data)
 
     async def action(self, entity: Entity, action: str):
         entity_def = entities.get(entity.type)

--- a/xsense/base.py
+++ b/xsense/base.py
@@ -3,7 +3,7 @@ import hashlib
 import hmac
 import json
 from datetime import datetime, timedelta, timezone
-from typing import Dict
+from typing import Dict, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -244,18 +244,51 @@ class XSenseBase:
         if volume < 0 or volume > 100:
             raise XSenseError('Volume must be between 0 and 100')
 
-    def build_config_state(self, entity: Entity, shadow: str, values: Dict):
+    def _bool_value(self, value):
+        if isinstance(value, bool):
+            return '1' if value else '0'
+        if value in (0, 1, '0', '1'):
+            return str(value)
+        raise XSenseError('Value must be a boolean or 0/1')
+
+    def _utc_timestamp(self):
+        return datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
+
+    def build_command_state(
+            self,
+            entity: Entity,
+            shadow: str,
+            values: Dict,
+            include_device: Optional[bool]=None,
+            include_time: bool=True,
+            include_user: bool=True
+    ):
         station = self._station_for_entity(entity)
+        if include_device is None:
+            include_device = not isinstance(entity, Station)
+
         desired = {
             "shadow": shadow,
             "stationSN": station.sn,
-            **values
         }
-
-        if not isinstance(entity, Station):
+        if include_device:
             desired["deviceSN"] = entity.sn
+        if include_time:
+            desired["time"] = self._utc_timestamp()
+        if include_user:
+            desired["userId"] = self.userid
 
+        desired.update(values)
         return station, {"state": {"desired": desired}}
+
+    def build_config_state(self, entity: Entity, shadow: str, values: Dict):
+        return self.build_command_state(
+            entity,
+            shadow,
+            values,
+            include_time=False,
+            include_user=False
+        )
 
     def has_action(self, entity: Entity, action: str):
         if entity_def := entities.get(entity.type):
@@ -263,19 +296,8 @@ class XSenseBase:
         return False
 
     def build_desired_state(self, entity: Entity, shadow: str, definition: Dict):
-        station = self._station_for_entity(entity)
-        t = datetime.now(timezone.utc)
-        timestamp = t.strftime('%Y%m%d%H%M%S')
-
-        desired = {
-            "shadow": shadow,
-            "stationSN": station.sn,
-            "time": timestamp,
-            "userId": self.userid
+        values = {
+            **definition.get('extra', {}),
+            **definition.get('data', {})
         }
-        if not isinstance(entity, Station):
-            desired["deviceSN"] = entity.sn
-        desired.update(definition.get('extra', {}))
-        desired.update(definition.get('data', {}))
-
-        return station, {"state": {"desired": desired}}
+        return self.build_command_state(entity, shadow, values)

--- a/xsense/base.py
+++ b/xsense/base.py
@@ -230,11 +230,6 @@ class XSenseBase:
             if station := house.get_station_by_sn(sn):
                 station.set_data(i)
 
-    def has_action(self, entity: Entity, action: str):
-        if entity_def := entities.get(entity.type):
-            return any(a for a in entity_def.get('actions', []) if a.get('action') == action)
-        return False
-
     def _station_for_entity(self, entity: Entity) -> Station:
         station = getattr(entity, 'station', None)
         if station:
@@ -242,6 +237,30 @@ class XSenseBase:
         if isinstance(entity, Station):
             return entity
         raise XSenseError(f'Entity type {entity.type} has no station')
+
+    def _validate_volume(self, volume: int):
+        if not isinstance(volume, int):
+            raise XSenseError('Volume must be an integer')
+        if volume < 0 or volume > 100:
+            raise XSenseError('Volume must be between 0 and 100')
+
+    def build_config_state(self, entity: Entity, shadow: str, values: Dict):
+        station = self._station_for_entity(entity)
+        desired = {
+            "shadow": shadow,
+            "stationSN": station.sn,
+            **values
+        }
+
+        if not isinstance(entity, Station):
+            desired["deviceSN"] = entity.sn
+
+        return station, {"state": {"desired": desired}}
+
+    def has_action(self, entity: Entity, action: str):
+        if entity_def := entities.get(entity.type):
+            return any(a for a in entity_def.get('actions', []) if a.get('action') == action)
+        return False
 
     def build_desired_state(self, entity: Entity, shadow: str, definition: Dict):
         station = self._station_for_entity(entity)

--- a/xsense/base.py
+++ b/xsense/base.py
@@ -11,7 +11,7 @@ from pycognito import AWSSRP
 
 from .entity import Entity
 from .entity_map import entities
-from .exceptions import AuthFailed
+from .exceptions import AuthFailed, XSenseError
 from .station import Station
 from .house import House
 
@@ -234,3 +234,29 @@ class XSenseBase:
         if entity_def := entities.get(entity.type):
             return any(a for a in entity_def.get('actions', []) if a.get('action') == action)
         return False
+
+    def _station_for_entity(self, entity: Entity) -> Station:
+        station = getattr(entity, 'station', None)
+        if station:
+            return station
+        if isinstance(entity, Station):
+            return entity
+        raise XSenseError(f'Entity type {entity.type} has no station')
+
+    def build_desired_state(self, entity: Entity, shadow: str, definition: Dict):
+        station = self._station_for_entity(entity)
+        t = datetime.now(timezone.utc)
+        timestamp = t.strftime('%Y%m%d%H%M%S')
+
+        desired = {
+            "shadow": shadow,
+            "stationSN": station.sn,
+            "time": timestamp,
+            "userId": self.userid
+        }
+        if not isinstance(entity, Station):
+            desired["deviceSN"] = entity.sn
+        desired.update(definition.get('extra', {}))
+        desired.update(definition.get('data', {}))
+
+        return station, {"state": {"desired": desired}}

--- a/xsense/entity.py
+++ b/xsense/entity.py
@@ -1,5 +1,5 @@
 from xsense.entity_map import entities
-from xsense.mapping import map_values
+from xsense.mapping import map_bool, map_values
 
 
 class Entity:
@@ -21,7 +21,7 @@ class Entity:
     def set_data(self, values: dict):
         data = values.copy()
         if 'online' in values:
-            self.online = values.pop('online') != '0'
+            self.online = map_bool(values.pop('online'))
         if values.get('onlineTime'):
             self.online = True
         data |= data.pop('status', {})

--- a/xsense/entity_map.py
+++ b/xsense/entity_map.py
@@ -6,13 +6,19 @@ class EntityType(Enum):
     ALARM = 'alarm'
     BASE = "base"
     BASESTATION = 'station'
+    CAMERA = 'camera'
     CO = "co"
     COMBI = 'combi'
     DOOR = 'door'
     HEAT = 'heat'
     KEYPAD = 'keypad'
+    LIGHT = 'light'
+    LISTENER = 'listener'
     MAILBOX = 'mailbox'
     MOTION = 'motion'
+    RADON = 'radon'
+    REMOTE = 'remote'
+    SMARTDROP = 'smartdrop'
     SMOKE = "smoke"
     TEMPERATURE = "temperature"
     WATER = "water"
@@ -56,8 +62,12 @@ def SATestAction(shadow = 'appSelfTest'):
 
 
 entities = {
-    'SAL51': {}, # listener
-    'SAL100': {}, # listener
+    'SAL51': {
+        'type': EntityType.LISTENER,
+    },
+    'SAL100': {
+        'type': EntityType.LISTENER,
+    },
     'SBS10': {
         'type': EntityType.BASESTATION,
     },
@@ -65,8 +75,18 @@ entities = {
         'type': EntityType.BASESTATION,
         'identifier': lambda entity: f'SBS50{entity.sn}',
     },
-    # SSC0A - Camera
-    # SSC0B
+    'SSC0A': {
+        'type': EntityType.CAMERA,
+    },
+    'SSC0B': {
+        'type': EntityType.CAMERA,
+    },
+    'SC01-MN': {
+        'type': EntityType.COMBI,
+    },
+    'SC01-MR': {
+        'type': EntityType.COMBI,
+    },
     'SC06-WX': {
         'identifier': lambda entity: f'SC06-WX-{entity.sn}',
         'type': EntityType.COMBI,
@@ -87,12 +107,33 @@ entities = {
             MuteAction('1')
         ]
     },
-    # 'SDA51': {}, - Driveway alarm
+    'SD11-MR': {
+        'type': EntityType.SMOKE,
+    },
+    'SD19-MN': {
+        'type': EntityType.SMOKE,
+    },
+    'SD19-MR': {
+        'type': EntityType.SMOKE,
+    },
+    'SDA51': {
+        'type': EntityType.ALARM,
+    },
     'SDS0A': {
         'type': EntityType.DOOR,
     },
-    # 'SES01': {}, - Door sensor
-    # 'SKF01': {}, - Remote Control
+    'SES01': {
+        'type': EntityType.DOOR,
+    },
+    'SKF01': {
+        'type': EntityType.REMOTE,
+    },
+    'SK0Z-3S': {
+        'type': EntityType.SMOKE,
+    },
+    'SKP01': {
+        'type': EntityType.KEYPAD,
+    },
     'SKP0A': {
         'type': EntityType.KEYPAD,
     },
@@ -110,9 +151,18 @@ entities = {
     'SMS0A': {
         'type': EntityType.MOTION,
     },
-    # 'SSD01': {},
-    # 'SPL51': {},
-    # 'SSL51': {},
+    'SMS01': {
+        'type': EntityType.MOTION,
+    },
+    'SPL51': {
+        'type': EntityType.LIGHT,
+    },
+    'SSD01': {
+        'type': EntityType.SMARTDROP,
+    },
+    'SSL51': {
+        'type': EntityType.LIGHT,
+    },
     'STH0A': {
         'type': EntityType.TEMPERATURE,
         'actions': [
@@ -127,6 +177,9 @@ entities = {
             MuteAction('1', 'extendMute')
         ],
     },
+    'STH0C': {
+        'type': EntityType.TEMPERATURE,
+    },
     'STH51': {
         'type': EntityType.TEMPERATURE,
         'actions': [
@@ -134,7 +187,15 @@ entities = {
             MuteAction('1', 'extendMute')
         ],
     },
-    # 'SWL51': {},
+    'SWL51': {
+        'type': EntityType.LIGHT,
+    },
+    'SWS0A': {
+        'type': EntityType.WATER,
+    },
+    'SWS0B': {
+        'type': EntityType.WATER,
+    },
     'SWS51': {
         'type': EntityType.WATER,
         'actions': [
@@ -142,7 +203,22 @@ entities = {
             MuteAction(shadow='appWater', topic='2nd_appwater', extra={'silencetime': '', 'setType': '0'})
         ],
     },
+    'CB0Z-3S': {
+        'type': EntityType.COMBI,
+    },
+    'LP/N-SA-0B': {
+        'type': EntityType.SMOKE,
+    },
+    'LP/N-SCA-0A': {
+        'type': EntityType.COMBI,
+    },
+    'XC0C-iA': {
+        'type': EntityType.CO,
+    },
     'XC0C-iR': {
+        'type': EntityType.CO,
+    },
+    'XC0M-iR': {
         'type': EntityType.CO,
     },
     'XC01-M': {
@@ -172,6 +248,9 @@ entities = {
             TestAction(shadow='app2ndSelfTest'),
             FireDrillAction()
         ]
+    },
+    'XR0A-iR': {
+        'type': EntityType.RADON,
     },
     'XP02S-MR': {
         'type': EntityType.SMOKE,
@@ -224,5 +303,29 @@ entities = {
     },
     'XPOA-IR': {
         'type': EntityType.COMBI,
+    },
+    'XP0H-MR': {
+        'type': EntityType.COMBI,
+    },
+    'XP0H-iR': {
+        'type': EntityType.COMBI,
+    },
+    'XP0J-iA': {
+        'type': EntityType.COMBI,
+    },
+    'XP0P-MR': {
+        'type': EntityType.COMBI,
+    },
+    'XS0B-iR': {
+        'type': EntityType.SMOKE,
+    },
+    'XS0E-iR': {
+        'type': EntityType.SMOKE,
+    },
+    'XS0F-PMA': {
+        'type': EntityType.SMOKE,
+    },
+    'XS0R-iA': {
+        'type': EntityType.SMOKE,
     },
 }

--- a/xsense/entity_map.py
+++ b/xsense/entity_map.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional, Union
 
 
 class EntityType(Enum):
@@ -24,7 +24,12 @@ class EntityType(Enum):
     WATER = "water"
 
 
-def MuteAction(shadow: str = 'appMute', topic: str|None|Callable = '2nd_appmute', extra: Dict|None=None):
+def MuteAction(
+        shadow: str = 'appMute',
+        topic: Union[str, Callable, None] = '2nd_appmute',
+        extra: Optional[Dict]=None,
+        mute_type: Optional[str]=None
+):
     data = {
         'action': 'mute',
         'topic': topic,
@@ -32,6 +37,8 @@ def MuteAction(shadow: str = 'appMute', topic: str|None|Callable = '2nd_appmute'
     }
     if extra:
         data['extra'] = extra
+    if mute_type is not None:
+        data.setdefault('extra', {})['muteType'] = mute_type
 
     return data
 
@@ -48,7 +55,8 @@ def FireDrillAction():
     return {
         'action': 'firedrill',
         'topic': '2nd_firedrill',
-        'shadow': 'appFireDrill'
+        'shadow': 'appFireDrill',
+        'data': {'drill': '1'}
     }
 
 
@@ -64,9 +72,15 @@ def SATestAction(shadow = 'appSelfTest'):
 entities = {
     'SAL51': {
         'type': EntityType.LISTENER,
+        'actions': [
+            MuteAction('appListener', mute_type='1'),
+        ],
     },
     'SAL100': {
         'type': EntityType.LISTENER,
+        'actions': [
+            MuteAction('appListener', mute_type='1'),
+        ],
     },
     'SBS10': {
         'type': EntityType.BASESTATION,
@@ -86,6 +100,9 @@ entities = {
     },
     'SC01-MR': {
         'type': EntityType.COMBI,
+        'actions': [
+            MuteAction('appSc07mrMute', mute_type='1'),
+        ],
     },
     'SC06-WX': {
         'identifier': lambda entity: f'SC06-WX-{entity.sn}',
@@ -98,26 +115,41 @@ entities = {
         'identifier': lambda entity: f'SC07-MR-{entity.sn}',
         'type': EntityType.COMBI,
         'actions': [
+            MuteAction('appSc07mrMute', mute_type='1'),
         ]
     },
     'SC07-WX': {
         'identifier': lambda entity: f'SC07-WX-{entity.sn}',
         'type': EntityType.COMBI,
         'actions': [
-            MuteAction('1')
+            MuteAction(mute_type='1')
         ]
     },
     'SD11-MR': {
         'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+        ],
     },
     'SD19-MN': {
         'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+        ],
     },
     'SD19-MR': {
         'type': EntityType.SMOKE,
     },
     'SDA51': {
         'type': EntityType.ALARM,
+        'actions': [
+            {
+                'action': 'mute',
+                'topic': '2nd_appdriveway',
+                'shadow': 'appDriveway',
+                'data': {'mute': '1'}
+            },
+        ],
     },
     'SDS0A': {
         'type': EntityType.DOOR,
@@ -130,6 +162,9 @@ entities = {
     },
     'SK0Z-3S': {
         'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+        ],
     },
     'SKP01': {
         'type': EntityType.KEYPAD,
@@ -167,14 +202,14 @@ entities = {
         'type': EntityType.TEMPERATURE,
         'actions': [
             TestAction('thSelfTest'),
-            MuteAction('1', 'extendMute')
+            MuteAction('extendMute', '2nd_appmute', extra={'type': 'STH0A'}, mute_type='1')
         ],
     },
     'STH0B': {
         'type': EntityType.TEMPERATURE,
         'actions': [
             TestAction('thSelfTest'),
-            MuteAction('1', 'extendMute')
+            MuteAction('extendMute', '2nd_appmute', extra={'type': 'STH0B'}, mute_type='1')
         ],
     },
     'STH0C': {
@@ -184,7 +219,7 @@ entities = {
         'type': EntityType.TEMPERATURE,
         'actions': [
             TestAction('thSelfTest'),
-            MuteAction('1', 'extendMute')
+            MuteAction('extendMute', '2nd_appmute', extra={'type': 'STH51'}, mute_type='1')
         ],
     },
     'SWL51': {
@@ -200,7 +235,7 @@ entities = {
         'type': EntityType.WATER,
         'actions': [
             TestAction('waterSelfTest'),
-            MuteAction(shadow='appWater', topic='2nd_appwater', extra={'silencetime': '', 'setType': '0'})
+            MuteAction(shadow='appWater', topic='2nd_appwater', extra={'silenceTime': '', 'setType': '0'})
         ],
     },
     'CB0Z-3S': {
@@ -208,6 +243,9 @@ entities = {
     },
     'LP/N-SA-0B': {
         'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+        ],
     },
     'LP/N-SCA-0A': {
         'type': EntityType.COMBI,
@@ -226,26 +264,28 @@ entities = {
         'type': EntityType.CO,
         'actions': [
             TestAction(shadow='appCoSelfTest'),
-            MuteAction('1', '"appCoMute')
+            MuteAction('appCoMute', mute_type='1')
         ]
     },
     'XC04-WX': {
         'identifier': lambda entity: f'XC04-WX-{entity.sn}',
         'type': EntityType.CO,
         'actions': [
-            MuteAction('1')
+            MuteAction(mute_type='1')
         ]
     },
     'XH02-M': {
         'type': EntityType.HEAT,
         'actions': [
             TestAction(shadow='appXh02mSelfTest'),
+            MuteAction('appXh02mMute', mute_type='1', extra={'userParam': 'source=1'}),
         ]
     },
     'XP0A-MR': {
         'type': EntityType.COMBI,
         'actions': [
             TestAction(shadow='app2ndSelfTest'),
+            MuteAction('appXp0amrMute', mute_type='1', extra={'userParam': 'source=1'}),
             FireDrillAction()
         ]
     },
@@ -275,7 +315,7 @@ entities = {
         'type': EntityType.SMOKE,
         'actions': [
             TestAction(),
-            MuteAction(),
+            MuteAction('app2ndMute', mute_type='1'),
             FireDrillAction(),
         ],
     },
@@ -291,6 +331,9 @@ entities = {
     },
     'XS0D-MR': {
         'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+        ],
     },
     'XS0D-MR61': {
         'type': EntityType.SMOKE,
@@ -306,6 +349,9 @@ entities = {
     },
     'XP0H-MR': {
         'type': EntityType.COMBI,
+        'actions': [
+            MuteAction('appSc07mrMute', mute_type='1'),
+        ],
     },
     'XP0H-iR': {
         'type': EntityType.COMBI,
@@ -315,6 +361,9 @@ entities = {
     },
     'XP0P-MR': {
         'type': EntityType.COMBI,
+        'actions': [
+            MuteAction('appSc07mrMute', mute_type='1'),
+        ],
     },
     'XS0B-iR': {
         'type': EntityType.SMOKE,
@@ -324,6 +373,10 @@ entities = {
     },
     'XS0F-PMA': {
         'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+            MuteAction('app2ndMute', mute_type='1'),
+        ],
     },
     'XS0R-iA': {
         'type': EntityType.SMOKE,

--- a/xsense/entity_map.py
+++ b/xsense/entity_map.py
@@ -203,6 +203,26 @@ entities = {
     'XS03-iWX': {
         # Smoke RF
         'type': EntityType.SMOKE,
+        'actions': [
+            TestAction(),
+        ],
     },
-    'XS03-WX': {}
+    'XS03-WX': {
+        'type': EntityType.SMOKE,
+    },
+    'XS0D-MR': {
+        'type': EntityType.SMOKE,
+    },
+    'XS0D-MR61': {
+        'type': EntityType.SMOKE,
+    },
+    'XC0C-MR': {
+        'type': EntityType.CO,
+    },
+    'XP0A-iR': {
+        'type': EntityType.COMBI,
+    },
+    'XPOA-IR': {
+        'type': EntityType.COMBI,
+    },
 }

--- a/xsense/entity_map.py
+++ b/xsense/entity_map.py
@@ -145,7 +145,7 @@ entities = {
         'actions': [
             {
                 'action': 'mute',
-                'topic': '2nd_appdriveway',
+                'topic': '2nd_driveway',
                 'shadow': 'appDriveway',
                 'data': {'mute': '1'}
             },

--- a/xsense/mapping.py
+++ b/xsense/mapping.py
@@ -1,5 +1,12 @@
 import typing
 
+
+def map_bool(value):
+    if isinstance(value, bool):
+        return value
+    return value in (1, '1')
+
+
 property_mapper = {
     '*': {
         'wifiRssi': 'wifiRSSI'
@@ -42,13 +49,15 @@ property_mapper = {
 type_mapping = {
     'batInfo': int,
     'rfLevel': int,
-    'alarmStatus': lambda x: x == '1',
-    'alarmEnabled': lambda x: x == '1',
-    'muteStatus': lambda x: x == '1',
-    'continuedAlarm': lambda x: x == '1',
+    'alarmStatus': map_bool,
+    'alarmEnabled': map_bool,
+    'muteStatus': map_bool,
+    'continuedAlarm': map_bool,
     'coPpm': int,
     'coLevel': int,
-    'isLifeEnd': lambda x: x == '1',
+    'isLifeEnd': map_bool,
+    'isOpen': map_bool,
+    'activate': map_bool,
     'temperature': float,
     'humidity': float
 }

--- a/xsense/mapping.py
+++ b/xsense/mapping.py
@@ -68,8 +68,10 @@ def map_type(k: str, value: typing.Any):
 
 
 def map_values(device_type: str, data: typing.Dict):
-    mapping = property_mapper[device_type] if device_type in property_mapper else {}
-    mapping.update(property_mapper.get('*', {}))
+    mapping = {
+        **property_mapper.get('*', {}),
+        **property_mapper.get(device_type, {}),
+    }
 
     return {
         mapping.get(k, k): map_type(mapping.get(k, k), v)

--- a/xsense/mapping.py
+++ b/xsense/mapping.py
@@ -47,6 +47,7 @@ property_mapper = {
 }
 
 type_mapping = {
+    'alarmVol': int,
     'batInfo': int,
     'rfLevel': int,
     'alarmStatus': map_bool,
@@ -58,6 +59,7 @@ type_mapping = {
     'isLifeEnd': map_bool,
     'isOpen': map_bool,
     'activate': map_bool,
+    'voiceVol': int,
     'temperature': float,
     'humidity': float
 }

--- a/xsense/mqtt_helper.py
+++ b/xsense/mqtt_helper.py
@@ -33,7 +33,7 @@ class MQTTHelper:
             signed = self.signer.presign_url(f'wss://{self.house.mqtt_server}/mqtt', self.house.mqtt_region)
             url_parts = signed.split("/")
             self._mqtt_path = "/" + "/".join(url_parts[3:])
-            _sig_age = datetime.now()
+            self._sig_age = datetime.now()
 
         return self._mqtt_path
 

--- a/xsense/station.py
+++ b/xsense/station.py
@@ -2,6 +2,7 @@ from typing import List, Dict
 
 from xsense.device import Device
 from xsense.entity import Entity
+from xsense.mapping import map_bool
 
 
 class Station(Entity):
@@ -19,7 +20,7 @@ class Station(Entity):
         self.entity_id = kwargs.get('stationId')
         self.name = kwargs.get('stationName')
         self.sn = kwargs.get('stationSn')
-        self.online = kwargs.get('onLine', True)
+        self.online = map_bool(kwargs.get('onLine', True))
         self.type = kwargs.get('category')
 
         self.has_alarm = False
@@ -30,7 +31,7 @@ class Station(Entity):
         self.device_order = data.get('deviceSort')
         result = {}
         result_sn = {}
-        for i in data.get('devices'):
+        for i in data.get('devices', []):
             d = Device(
                 self,
                 **i

--- a/xsense/station.py
+++ b/xsense/station.py
@@ -62,6 +62,9 @@ class Station(Entity):
             if v := values.get(k):
                 self._alarm_data[k] = v
 
+        if safe_mode := values.get('safeMode'):
+            self.safe_mode = safe_mode
+
     @property
     def alarm_data(self):
         return self._alarm_data

--- a/xsense/xsense.py
+++ b/xsense/xsense.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Optional
 
 import requests
 
@@ -225,6 +225,25 @@ class XSense(XSenseBase):
         station, data = self.build_desired_state(entity, shadow, definition)
 
         return self.do_thing(station, topic, data)
+
+    def set_alarm_volume(self, entity: Entity, volume: int, alarm_tone: Optional[str]=None, mute: Optional[str]=None):
+        self._validate_volume(volume)
+        values = {
+            "alarmVol": str(volume),
+        }
+        if alarm_tone is not None:
+            values["alarmTone"] = alarm_tone
+        if mute is not None:
+            values["mute"] = mute
+
+        shadow = "infoBase" if isinstance(entity, Station) else "infoDev"
+        station, data = self.build_config_state(entity, shadow, values)
+        return self.do_thing(station, f'2nd_cfg_{entity.sn}', data)
+
+    def set_voice_volume(self, station: Station, volume: int):
+        self._validate_volume(volume)
+        station, data = self.build_config_state(station, "infoBase", {"voiceVol": str(volume)})
+        return self.do_thing(station, f'2nd_cfg_{station.sn}', data)
 
     def action(self, entity: Entity, action: str):
         entity_def = entities.get(entity.type)

--- a/xsense/xsense.py
+++ b/xsense/xsense.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 import requests
 
@@ -226,6 +226,11 @@ class XSense(XSenseBase):
 
         return self.do_thing(station, topic, data)
 
+    def set_device_config(self, entity: Entity, **values):
+        shadow = "infoBase" if isinstance(entity, Station) else "infoDev"
+        station, data = self.build_config_state(entity, shadow, values)
+        return self.do_thing(station, f'2nd_cfg_{entity.sn}', data)
+
     def set_alarm_volume(self, entity: Entity, volume: int, alarm_tone: Optional[str]=None, mute: Optional[str]=None):
         self._validate_volume(volume)
         values = {
@@ -244,6 +249,238 @@ class XSense(XSenseBase):
         self._validate_volume(volume)
         station, data = self.build_config_state(station, "infoBase", {"voiceVol": str(volume)})
         return self.do_thing(station, f'2nd_cfg_{station.sn}', data)
+
+    def set_station_mode(self, station: Station, safe_mode: str, force_arm: Optional[str]=None):
+        values = {
+            "userParam": "source=1",
+            "source": "1",
+            "safeMode": safe_mode,
+        }
+        if force_arm is not None:
+            values["forceArm"] = force_arm
+
+        station, data = self.build_command_state(
+            station,
+            "appMode",
+            values,
+            include_device=False,
+            include_time=False
+        )
+        return self.do_thing(station, "2nd_appmode", data)
+
+    def trigger_sos(self, station: Station, sos_type: str='1'):
+        station, data = self.build_command_state(
+            station,
+            "sosDown",
+            {
+                "userParam": "source=1",
+                "sosType": sos_type,
+            },
+            include_device=False
+        )
+        return self.do_thing(station, "2nd_sosdown", data)
+
+    def cancel_sos(self, station: Station):
+        station, data = self.build_command_state(
+            station,
+            "sosDown",
+            {"sosStatus": "0"},
+            include_device=False
+        )
+        return self.do_thing(station, "sosdown", data)
+
+    def cancel_alarm(self, station: Station):
+        station, data = self.build_command_state(
+            station,
+            "alarmCancel",
+            {"cancelTime": self._utc_timestamp()},
+            include_device=False,
+            include_time=False
+        )
+        return self.do_thing(station, "alarmcancel", data)
+
+    def set_fire_drill(
+            self,
+            entity: Entity,
+            drill: Union[bool, str]=True,
+            drill_time: Optional[str]=None,
+            alarm_type: Optional[str]=None,
+            alarm_vol: Optional[str]=None,
+            alarm_tone: Optional[str]=None,
+            location: Optional[str]=None,
+            stop_reason: Optional[str]=None
+    ):
+        values = {"drill": self._bool_value(drill)}
+        optional = {
+            "drillTime": drill_time,
+            "alarmType": alarm_type,
+            "alarmVol": alarm_vol,
+            "alarmTone": alarm_tone,
+            "location": location,
+            "stopReason": stop_reason,
+        }
+        values.update({k: v for k, v in optional.items() if v is not None})
+        if not isinstance(entity, Station):
+            values["deviceType"] = entity.type
+
+        station, data = self.build_command_state(
+            entity,
+            "appFireDrill",
+            values,
+            include_device=not isinstance(entity, Station)
+        )
+        return self.do_thing(station, "2nd_firedrill", data)
+
+    def set_sos_sound(self, station: Station, sos_sound: str):
+        station, data = self.build_command_state(
+            station,
+            "sosParam",
+            {
+                "userParam": "source=1",
+                "sosSound": sos_sound,
+            },
+            include_device=False
+        )
+        return self.do_thing(station, "2nd_sosparam", data)
+
+    def activate_device(self, entity: Entity):
+        station, data = self.build_command_state(
+            entity,
+            "app2ndActivate",
+            {"activate": "1"},
+            include_device=True
+        )
+        return self.do_thing(station, "2nd_appactivate", data)
+
+    def set_install_guide_test(
+            self,
+            entity: Entity,
+            active: Union[bool, str]=True,
+            dev_type: Optional[str]=None,
+            test_time: str='180',
+            detc_sens: Optional[str]=None
+    ):
+        values = {
+            "devType": dev_type or entity.type,
+            "test": self._bool_value(active),
+            "testTime": test_time,
+        }
+        if detc_sens is not None:
+            values["detcSens"] = detc_sens
+
+        station, data = self.build_command_state(entity, "appInstallGuide", values, include_device=True)
+        return self.do_thing(station, "2nd_appinstallguide", data)
+
+    def signal_test(
+            self,
+            entity: Entity,
+            dev_type: Optional[str]=None,
+            test: Union[bool, str]=True,
+            test_time: str='5'
+    ):
+        station, data = self.build_command_state(
+            entity,
+            "signalTest",
+            {
+                "devType": dev_type or entity.type,
+                "test": self._bool_value(test),
+                "testTime": test_time,
+            },
+            include_device=True
+        )
+        return self.do_thing(station, f'2nd_signaltest_{entity.sn}', data)
+
+    def set_motion_test(self, entity: Entity, active: Union[bool, str]=True, dev_type: str='SMS01'):
+        station, data = self.build_command_state(
+            entity,
+            "testIR",
+            {
+                "devType": dev_type,
+                "testIR": self._bool_value(active),
+            },
+            include_device=True,
+            include_time=False,
+            include_user=False
+        )
+        return self.do_thing(station, "testir", data)
+
+    def set_light_power(self, entity: Entity, on: Union[bool, str]):
+        station, data = self.build_command_state(
+            entity,
+            "lampPower",
+            {
+                "userParam": "source=1",
+                "isOn": self._bool_value(on),
+                "dev": entity.sn,
+            },
+            include_device=False
+        )
+        return self.do_thing(station, "2nd_lamppower", data)
+
+    def set_light_group_power(
+            self,
+            station: Station,
+            group_id: str,
+            device_sns: List[str],
+            on: Union[bool, str],
+            timeout: str='180'
+    ):
+        station, data = self.build_command_state(
+            station,
+            "groupLampPower",
+            {
+                "userParam": "source=1",
+                "timeOut": timeout,
+                "groupId": group_id,
+                "devs": device_sns,
+                "isOn": self._bool_value(on),
+            },
+            include_device=False
+        )
+        return self.do_thing(station, "2nd_grouppower", data)
+
+    def mute_water(
+            self,
+            entity: Entity,
+            set_type: str='0',
+            silence_time: str='',
+            trigger_source: Optional[str]=None
+    ):
+        values = {
+            "setType": set_type,
+            "silenceTime": silence_time,
+        }
+        if trigger_source is not None:
+            values["triggerSource"] = trigger_source
+
+        station, data = self.build_command_state(
+            entity,
+            "appWater",
+            values,
+            include_device=True
+        )
+        return self.do_thing(station, "2nd_appwater", data)
+
+    def mute_temperature_humidity(self, entity: Entity, mute_type: str='1', sensor_type: Optional[str]=None):
+        station, data = self.build_command_state(
+            entity,
+            "extendMute",
+            {
+                "muteType": mute_type,
+                "type": sensor_type or entity.type,
+            },
+            include_device=True
+        )
+        return self.do_thing(station, "2nd_appmute", data)
+
+    def mute_driveway(self, entity: Entity, mute: Union[bool, str]=True, topic: str='2nd_driveway'):
+        station, data = self.build_command_state(
+            entity,
+            "appDriveway",
+            {"mute": self._bool_value(mute)},
+            include_device=True
+        )
+        return self.do_thing(station, topic, data)
 
     def action(self, entity: Entity, action: str):
         entity_def = entities.get(entity.type)

--- a/xsense/xsense.py
+++ b/xsense/xsense.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict
 
 import requests
@@ -222,22 +222,9 @@ class XSense(XSenseBase):
             raise APIFailure(f'Unable to retrieve station data: {self._lastres.status_code}/{self._lastres.text}')
 
     def set_state(self, entity: Entity, shadow: str, topic: str, definition: Dict):
-        station = entity.station
-        t = datetime.now()
-        timestamp = t.strftime('%Y%m%d%H%M%S')
+        station, data = self.build_desired_state(entity, shadow, definition)
 
-        desired = {
-            "deviceSN": entity.sn,
-            "shadow": shadow,
-            "stationSN": station.sn,
-            "time": timestamp,
-            "userId": self.userid
-        }
-        desired.update(definition.get('extra', {}))
-
-        data = {"state": {"desired": desired}}
-
-        res = self.do_thing(station, topic, data)
+        return self.do_thing(station, topic, data)
 
     def action(self, entity: Entity, action: str):
         entity_def = entities.get(entity.type)
@@ -251,4 +238,4 @@ class XSense(XSenseBase):
         topic = action_def.get('topic')
         if callable(topic):
             topic = topic(entity)
-        self.set_state(entity, action_def['shadow'], topic, action_def)
+        return self.set_state(entity, action_def['shadow'], topic, action_def)


### PR DESCRIPTION
## Summary
- add sync and async helpers for APK-observed control payloads
- add alarm and voice volume setters using config shadow updates
- add station mode, SOS, alarm cancel, fire drill, activation, test, light, and device mute helpers
- centralize command payload construction so station-level and device-level commands include the right fields
- use the response-backed driveway mute topic by default while allowing callers to override it

## Notes
- Builds on #22 and #23, so the visible diff should shrink after those merge.
- No docs changes included.

## Validation
- Parsed all xsense Python files with AST
- Ran `git diff --check` 
- Ran mocked sync/async payload checks for station commands, volume setters, light/group commands, water/temp/driveway mutes, and action metadata