### PR TITLE
Add history query helpers

### DIFF
--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -81,9 +81,29 @@ The following requests have been identified:
 +------------+---------------------------+-----------------+
 | 102008     | Query rooms               |                 |
 +------------+---------------------------+-----------------+
+| 104001     | Query daily history       |                 |
++------------+---------------------------+-----------------+
+| 104006     | Query monthly history     |                 |
++------------+---------------------------+-----------------+
+| 104007     | Query station history     | station/device  |
++------------+---------------------------+-----------------+
+| 104008     | Query station month       | station/device  |
++------------+---------------------------+-----------------+
+| 104009     | Query device CO history   | device          |
++------------+---------------------------+-----------------+
+| 104010     | Query device CO details   | device          |
++------------+---------------------------+-----------------+
+| 104014     | Query station CO history  | station         |
++------------+---------------------------+-----------------+
+| 104015     | Query station CO details  | station         |
++------------+---------------------------+-----------------+
+| 104020     | Query STH chart history   | temp/humidity   |
++------------+---------------------------+-----------------+
 | 107002     | Get profile info          |                 |
 +------------+---------------------------+-----------------+
 | 120001     | Exception log             |                 |
++------------+---------------------------+-----------------+
+| 505001     | Query dispatch history    | security        |
 +------------+---------------------------+-----------------+
 
 
@@ -142,6 +162,93 @@ Params:
  :utctimestamp: int / 0
  :houseId: string
 
+104001: Query daily history
+---------------------------
+Params:
+ :houseId: string
+ :dayTime: string (yyyyMMdd)
+ :timeZone: string
+ :nextToken: string (optional)
+
+Response:
+ :alarms: list
+ :nextToken: string
+
+104006: Query monthly history
+-----------------------------
+Params:
+ :houseId: string
+ :hisMonth: string (yyyyMM)
+ :timeZone: string
+
+Response:
+ :history counts: list
+
+104007: Query station history
+-----------------------------
+Params:
+ :houseId: string
+ :stationId: string
+ :deviceId: string (optional)
+ :dayTime: string (yyyyMMdd)
+ :timeZone: string
+ :nextToken: string (optional)
+
+Response:
+ :alarms: list
+ :nextToken: string
+
+104008: Query station monthly history
+-------------------------------------
+Params:
+ :houseId: string
+ :stationId: string
+ :deviceId: string
+ :hisMonth: string (yyyyMM)
+ :timeZone: string
+
+Response:
+ :history counts: list
+
+104009 / 104014: Query CO PPM history list
+------------------------------------------
+104009 is used when querying a specific device. 104014 is used when querying a station.
+
+Params:
+ :stationId: string
+ :deviceId: string (104009 only)
+ :timeZone: string
+
+Response:
+ :CO PPM history days: list
+
+104010 / 104015: Query CO PPM history details
+---------------------------------------------
+104010 is used when querying a specific device. 104015 is used when querying a station.
+
+Params:
+ :houseId: string
+ :stationId: string
+ :deviceId: string (104010 only)
+ :dayTime: string (yyyyMMdd)
+ :timeZone: string
+
+Response:
+ :CO PPM readings: list
+
+104020: Query temperature/humidity chart history
+------------------------------------------------
+Params:
+ :houseId: string
+ :stationId: string
+ :lastTime: string
+ :nextToken: string (optional)
+
+Response:
+ :dataList: list
+ :lastTime: string
+ :nextToken: string
+
 
 107002: Get profile info
 ------------------------
@@ -159,6 +266,16 @@ Response:
 120001: Exception log
 ---------------------
 Looks like an API to log client errors
+
+505001: Query security dispatch history
+---------------------------------------
+Params:
+ :serverId: string
+ :nextToken: string (optional)
+
+Response:
+ :dispatch history: list
+ :nextToken: string
 
 506001: query trial state
 -------------------------

--- a/xsense/async_xsense.py
+++ b/xsense/async_xsense.py
@@ -1,7 +1,7 @@
 import asyncio
 from datetime import datetime
 import json
-from typing import Dict
+from typing import Dict, Optional
 
 import aiohttp
 
@@ -188,6 +188,115 @@ class AsyncXSense(XSenseBase):
             'utctimestamp': "0"
         }
         return await self.api_call("103007", **params)
+
+    async def get_history(self, houseId: str, dayTime: str, timeZone: str, nextToken: Optional[str] = None):
+        params = {
+            'houseId': houseId,
+            'dayTime': dayTime,
+            'timeZone': timeZone,
+        }
+        if nextToken:
+            params['nextToken'] = nextToken
+        return await self.api_call("104001", **params)
+
+    async def get_history_month(self, houseId: str, hisMonth: str, timeZone: str):
+        params = {
+            'houseId': houseId,
+            'hisMonth': hisMonth,
+            'timeZone': timeZone,
+        }
+        return await self.api_call("104006", **params)
+
+    async def get_station_history(
+        self,
+        houseId: str,
+        stationId: str,
+        dayTime: str,
+        timeZone: str,
+        deviceId: Optional[str] = None,
+        nextToken: Optional[str] = None,
+    ):
+        params = {
+            'houseId': houseId,
+            'dayTime': dayTime,
+            'timeZone': timeZone,
+            'stationId': stationId,
+        }
+        if deviceId:
+            params['deviceId'] = deviceId
+        if nextToken:
+            params['nextToken'] = nextToken
+        return await self.api_call("104007", **params)
+
+    async def get_station_history_month(
+        self,
+        houseId: str,
+        stationId: str,
+        deviceId: str,
+        hisMonth: str,
+        timeZone: str,
+    ):
+        params = {
+            'houseId': houseId,
+            'hisMonth': hisMonth,
+            'timeZone': timeZone,
+            'stationId': stationId,
+            'deviceId': deviceId,
+        }
+        return await self.api_call("104008", **params)
+
+    async def get_security_history(self, serverId: str, nextToken: Optional[str] = None):
+        params = {
+            'serverId': serverId,
+        }
+        if nextToken:
+            params['nextToken'] = nextToken
+        return await self.api_call("505001", **params)
+
+    async def get_sth_history(
+        self,
+        houseId: str,
+        stationId: str,
+        lastTime: str = "",
+        nextToken: Optional[str] = None,
+    ):
+        params = {
+            'houseId': houseId,
+            'stationId': stationId,
+            'lastTime': lastTime,
+        }
+        if nextToken:
+            params['nextToken'] = nextToken
+        return await self.api_call("104020", **params)
+
+    async def get_co_ppm_history(self, stationId: str, timeZone: str, deviceId: Optional[str] = None):
+        params = {
+            'stationId': stationId,
+            'timeZone': timeZone,
+        }
+        if deviceId:
+            params['deviceId'] = deviceId
+            return await self.api_call("104009", **params)
+        return await self.api_call("104014", **params)
+
+    async def get_co_ppm_history_details(
+        self,
+        houseId: str,
+        stationId: str,
+        dayTime: str,
+        timeZone: str,
+        deviceId: Optional[str] = None,
+    ):
+        params = {
+            'houseId': houseId,
+            'stationId': stationId,
+            'dayTime': dayTime,
+            'timeZone': timeZone,
+        }
+        if deviceId:
+            params['deviceId'] = deviceId
+            return await self.api_call("104010", **params)
+        return await self.api_call("104015", **params)
 
     async def get_house_state(self, house: House):
         for page in ('mainpage', '2nd_mainpage'):

--- a/xsense/xsense.py
+++ b/xsense/xsense.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Dict
+from typing import Dict, Optional
 
 import requests
 
@@ -167,6 +167,115 @@ class XSense(XSenseBase):
             'utctimestamp': "0"
         }
         return self.api_call("103007", **params)
+
+    def get_history(self, houseId: str, dayTime: str, timeZone: str, nextToken: Optional[str] = None):
+        params = {
+            'houseId': houseId,
+            'dayTime': dayTime,
+            'timeZone': timeZone,
+        }
+        if nextToken:
+            params['nextToken'] = nextToken
+        return self.api_call("104001", **params)
+
+    def get_history_month(self, houseId: str, hisMonth: str, timeZone: str):
+        params = {
+            'houseId': houseId,
+            'hisMonth': hisMonth,
+            'timeZone': timeZone,
+        }
+        return self.api_call("104006", **params)
+
+    def get_station_history(
+        self,
+        houseId: str,
+        stationId: str,
+        dayTime: str,
+        timeZone: str,
+        deviceId: Optional[str] = None,
+        nextToken: Optional[str] = None,
+    ):
+        params = {
+            'houseId': houseId,
+            'dayTime': dayTime,
+            'timeZone': timeZone,
+            'stationId': stationId,
+        }
+        if deviceId:
+            params['deviceId'] = deviceId
+        if nextToken:
+            params['nextToken'] = nextToken
+        return self.api_call("104007", **params)
+
+    def get_station_history_month(
+        self,
+        houseId: str,
+        stationId: str,
+        deviceId: str,
+        hisMonth: str,
+        timeZone: str,
+    ):
+        params = {
+            'houseId': houseId,
+            'hisMonth': hisMonth,
+            'timeZone': timeZone,
+            'stationId': stationId,
+            'deviceId': deviceId,
+        }
+        return self.api_call("104008", **params)
+
+    def get_security_history(self, serverId: str, nextToken: Optional[str] = None):
+        params = {
+            'serverId': serverId,
+        }
+        if nextToken:
+            params['nextToken'] = nextToken
+        return self.api_call("505001", **params)
+
+    def get_sth_history(
+        self,
+        houseId: str,
+        stationId: str,
+        lastTime: str = "",
+        nextToken: Optional[str] = None,
+    ):
+        params = {
+            'houseId': houseId,
+            'stationId': stationId,
+            'lastTime': lastTime,
+        }
+        if nextToken:
+            params['nextToken'] = nextToken
+        return self.api_call("104020", **params)
+
+    def get_co_ppm_history(self, stationId: str, timeZone: str, deviceId: Optional[str] = None):
+        params = {
+            'stationId': stationId,
+            'timeZone': timeZone,
+        }
+        if deviceId:
+            params['deviceId'] = deviceId
+            return self.api_call("104009", **params)
+        return self.api_call("104014", **params)
+
+    def get_co_ppm_history_details(
+        self,
+        houseId: str,
+        stationId: str,
+        dayTime: str,
+        timeZone: str,
+        deviceId: Optional[str] = None,
+    ):
+        params = {
+            'houseId': houseId,
+            'stationId': stationId,
+            'dayTime': dayTime,
+            'timeZone': timeZone,
+        }
+        if deviceId:
+            params['deviceId'] = deviceId
+            return self.api_call("104010", **params)
+        return self.api_call("104015", **params)
 
     def get_house_state(self, house: House):
         for page in ('mainpage', '2nd_mainpage'):


### PR DESCRIPTION
## Summary
- add sync and async helpers for APK-backed history endpoints
- cover daily/monthly event history, station/device history, security dispatch history, STH chart history, and CO PPM history
- require callers to pass the timezone used for timezone-sensitive history queries

## Validation
- AST parsed all package modules
- checked generated sync and async API payloads with mocked api_call
- ran git diff --check