### PR TITLE
Reuse HTTP sessions

### DIFF
--- a/xsense/async_xsense.py
+++ b/xsense/async_xsense.py
@@ -15,6 +15,28 @@ from xsense.station import Station
 
 
 class AsyncXSense(XSenseBase):
+    def __init__(self, session=None):
+        super().__init__()
+        self.session = session
+        self._owns_session = session is None
+
+    async def _get_session(self):
+        if self.session is None or self.session.closed:
+            self.session = aiohttp.ClientSession()
+            self._owns_session = True
+        return self.session
+
+    async def close(self):
+        if self._owns_session and self.session and not self.session.closed:
+            await self.session.close()
+
+    async def __aenter__(self):
+        await self._get_session()
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        await self.close()
+
     async def api_call(self, code, unauth=False, **kwargs):
         data = {
             **kwargs
@@ -29,38 +51,38 @@ class AsyncXSense(XSenseBase):
             headers = {'Authorization': self.access_token}
             mac = self._calculate_mac(data)
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f'{self.API}/app',
-                json={
-                    **data,
-                    "clientType": self.CLIENTYPE,
-                    "mac": mac,
-                    "appVersion": self.VERSION,
-                    "bizCode": code,
-                    "appCode": self.APPCODE,
-                },
-                headers=headers
-            ) as response:
-                self._lastres = response
+        session = await self._get_session()
+        async with session.post(
+            f'{self.API}/app',
+            json={
+                **data,
+                "clientType": self.CLIENTYPE,
+                "mac": mac,
+                "appVersion": self.VERSION,
+                "bizCode": code,
+                "appCode": self.APPCODE,
+            },
+            headers=headers
+        ) as response:
+            self._lastres = response
 
-                data = await response.json()
+            data = await response.json()
 
-                if response.status >= 400:
-                    message = data.get('message') or 'unknown error'
-                    raise APIFailure(f'API failure: {response.status}/{message}')
+            if response.status >= 400:
+                message = data.get('message') or 'unknown error'
+                raise APIFailure(f'API failure: {response.status}/{message}')
 
-                if 'reCode' not in data:
-                    raise APIFailure('API failure: Cannot understand response')
+            if 'reCode' not in data:
+                raise APIFailure('API failure: Cannot understand response')
 
-                if data['reCode'] != 200:
-                    errCode = data.get('errCode', 0)
-                    if errCode in ('10000008', '10000020'):
-                        raise SessionExpired(data.get('reMsg'))
-                    raise APIFailure(
-                        f"Request for code {code} failed with error {errCode}/{data['reCode']} {data.get('reMsg')}"
-                    )
-                return data['reData']
+            if data['reCode'] != 200:
+                errCode = data.get('errCode', 0)
+                if errCode in ('10000008', '10000020'):
+                    raise SessionExpired(data.get('reMsg'))
+                raise APIFailure(
+                    f"Request for code {code} failed with error {errCode}/{data['reCode']} {data.get('reMsg')}"
+                )
+            return data['reData']
 
     async def get_house(self, house: House, page: str):
         if self._aws_token_expiring():
@@ -68,13 +90,13 @@ class AsyncXSense(XSenseBase):
 
         url, headers = self._house_request(house, page)
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                url,
-                headers=headers
-            ) as response:
-                self._lastres = response
-                return await response.json()
+        session = await self._get_session()
+        async with session.get(
+            url,
+            headers=headers
+        ) as response:
+            self._lastres = response
+            return await response.json()
 
     async def get_thing(self, station: Station, page: str):
         if self._aws_token_expiring():
@@ -82,13 +104,13 @@ class AsyncXSense(XSenseBase):
 
         url, headers = self._thing_request(station, page)
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                url,
-                headers=headers
-            ) as response:
-                self._lastres = response
-                return await response.json()
+        session = await self._get_session()
+        async with session.get(
+            url,
+            headers=headers
+        ) as response:
+            self._lastres = response
+            return await response.json()
 
     async def do_thing(self, station: Station, page: str, data: Dict):
         if self._aws_token_expiring():
@@ -96,14 +118,14 @@ class AsyncXSense(XSenseBase):
 
         url, headers = self._thing_request(station, page, data)
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                url,
-                json=data,
-                headers=headers
-            ) as response:
-                self._lastres = response
-                return await response.json()
+        session = await self._get_session()
+        async with session.post(
+            url,
+            json=data,
+            headers=headers
+        ) as response:
+            self._lastres = response
+            return await response.json()
 
     async def login(self, username, password):
         await asyncio.get_event_loop().run_in_executor(None, self.sync_login, username, password)
@@ -111,18 +133,18 @@ class AsyncXSense(XSenseBase):
 
     async def refresh(self):
         url, data, headers = self._refresh_request()
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                url, json=data, headers=headers
-            ) as response:
-                self._lastres = response
-                text = await response.text()
-                data = json.loads(text)
+        session = await self._get_session()
+        async with session.post(
+            url, json=data, headers=headers
+        ) as response:
+            self._lastres = response
+            text = await response.text()
+            data = json.loads(text)
 
-                if response.status == 400:
-                    raise SessionExpired(data.get('message', 'token refresh failed'))
+            if response.status == 400:
+                raise SessionExpired(data.get('message', 'token refresh failed'))
 
-                self._parse_refresh_result(data.get('AuthenticationResult', {}))
+            self._parse_refresh_result(data.get('AuthenticationResult', {}))
 
     async def init(self):
         await self.get_client_info()

--- a/xsense/xsense.py
+++ b/xsense/xsense.py
@@ -13,6 +13,21 @@ from xsense.station import Station
 
 
 class XSense(XSenseBase):
+    def __init__(self, session=None):
+        super().__init__()
+        self.session = session or requests.Session()
+        self._owns_session = session is None
+
+    def close(self):
+        if self._owns_session:
+            self.session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+
     def api_call(self, code, unauth=False, **kwargs):
         data = {
             **kwargs
@@ -27,7 +42,7 @@ class XSense(XSenseBase):
             headers = {'Authorization': self.access_token}
             mac = self._calculate_mac(data)
 
-        res = requests.post(
+        res = self.session.post(
             f'{self.API}/app',
             json={
                 **data,
@@ -62,7 +77,7 @@ class XSense(XSenseBase):
             self.load_aws()
 
         url, headers = self._house_request(house, page)
-        res = requests.get(url, headers=headers)
+        res = self.session.get(url, headers=headers)
         self._lastres = res
         return res.json()
 
@@ -71,7 +86,7 @@ class XSense(XSenseBase):
             self.load_aws()
 
         url, headers = self._thing_request(station, page)
-        res = requests.get(url, headers=headers)
+        res = self.session.get(url, headers=headers)
         self._lastres = res
         return res.json()
 
@@ -80,7 +95,7 @@ class XSense(XSenseBase):
             self.load_aws()
 
         url, headers = self._thing_request(station, page, data)
-        res = requests.post(url, headers=headers, json=data)
+        res = self.session.post(url, headers=headers, json=data)
         self._lastres = res
         return res.json()
 
@@ -91,7 +106,7 @@ class XSense(XSenseBase):
     def refresh(self):
         url, data, headers = self._refresh_request()
 
-        res = requests.post(
+        res = self.session.post(
             url,
             json=data,
             headers=headers


### PR DESCRIPTION
## Summary
- reuse a persistent `requests.Session` in the sync client
- reuse a persistent `aiohttp.ClientSession` in the async client
- add close/context-manager support so callers can cleanly release owned sessions

## Why
This reduces avoidable connection setup and TLS churn during normal refresh loops without changing the number or meaning of X-Sense API or shadow requests.

## Validation
- AST parsed all package modules
- checked mocked sync and async session reuse behavior
- ran git diff --check